### PR TITLE
added commit_on_success to context context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Packaging files:
 *.eggs
+*.egg-info/
 
 # Installation artifacts
 src

--- a/edx_solutions_projects/management/commands/rename_projects_app.py
+++ b/edx_solutions_projects/management/commands/rename_projects_app.py
@@ -4,6 +4,7 @@ Management command to rename projects app to edx_solutions_projects
 import logging
 from south.db import db
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 log = logging.getLogger(__name__)
 
@@ -34,17 +35,18 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         log.info('renaming projects app and related tables')
-        db.execute(
-            "UPDATE south_migrationhistory SET app_name = %s WHERE app_name = %s", [self.new_appname, self.old_appname]
-        )
-        db.execute(
-            "UPDATE django_content_type SET app_label = %s WHERE app_label = %s", [self.new_appname, self.old_appname]
-        )
-
-        for table_name in get_table_names():
-            db.rename_table(
-                '{old_app}_{table_name}'.format(old_app=self.old_appname, table_name=table_name),
-                '{new_app}_{table_name}'.format(new_app=self.new_appname, table_name=table_name),
+        with transaction.commit_on_success():
+            db.execute(
+                "UPDATE south_migrationhistory SET app_name = %s WHERE app_name = %s", [self.new_appname, self.old_appname]
+            )
+            db.execute(
+                "UPDATE django_content_type SET app_label = %s WHERE app_label = %s", [self.new_appname, self.old_appname]
             )
 
-        log.info('projects app and related tables successfully renamed')
+            for table_name in get_table_names():
+                db.rename_table(
+                    '{old_app}_{table_name}'.format(old_app=self.old_appname, table_name=table_name),
+                    '{new_app}_{table_name}'.format(new_app=self.new_appname, table_name=table_name),
+                )
+
+            log.info('projects app and related tables successfully renamed')

--- a/edx_solutions_projects/management/commands/tests/test_rename_projects_app.py
+++ b/edx_solutions_projects/management/commands/tests/test_rename_projects_app.py
@@ -57,9 +57,9 @@ class RenameProjectsAppTests(TestCase):
 
         return table_name in tables
 
-    def test_rename_organizations_app(self):
+    def test_rename_projects_app(self):
         """
-        Test the organizations renaming
+        Test the projects app renaming
         """
         for table_name in self.table_names:
             self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.0.5',
+    version='1.0.6',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR wraps database operations around `transaction.commit_on_success` context manager to make sure changes are only committed when all statements are executed successfully.

@saleem-latif would you please review?
