### PR TITLE
WorkgroupsViewSet modified to fix failed test

### DIFF
--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -151,6 +151,7 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
                 if assignment_type not in dict(CourseCohort.ASSIGNMENT_TYPE_CHOICES).keys():
                     message = "Not a valid assignment type, '{}'".format(assignment_type)
                     return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+                workgroup = self.get_object()
                 cohort = add_cohort(course_key, workgroup.cohort_name, assignment_type)
                 for workgroup_user in workgroup.users.all():
                     add_user_to_cohort(cohort, workgroup_user.username)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.0',
+    version='1.1.1',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
added a line in WorkgroupsViewSet to get workgroup object after saving. previously a test was failing due to change in query set. reason for queryset cahnges is explained in YONK-769
@ziafazal can you please review this change? 
