### PR TITLE
Add management command to clean up unneeded image.png submissions

### DIFF
--- a/edx_solutions_projects/management/commands/remove_accidentally_pasted_uploads.py
+++ b/edx_solutions_projects/management/commands/remove_accidentally_pasted_uploads.py
@@ -1,0 +1,30 @@
+"""
+Management command to remove spurious workgroup submissions of image.png files
+created due to an issue in xblock-group-project-v2 before v0.4.9 where it would
+upload the image component of anything copied into the clipboard.
+"""
+import logging
+from django.core.management.base import BaseCommand
+from edx_solutions_projects.models import WorkgroupSubmission
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Removes spurious spurious workgroup submissions containing "image.png" due
+    to an issue in xblock-group-project-v2 < v0.4.9
+    """
+    help = 'Removes spurious workgroup submissions containing "image.png"'
+
+    def handle(self, *args, **options):
+        log.info('Deleting workgroup submissions containing a document called "image.png"')
+
+        choice = raw_input('Are you sure? [yn]').lower()
+        if choice == 'y' or choice == 'yes':
+            WorkgroupSubmission.objects.filter(
+                document_filename='image.png',
+                document_id=u'Kickoff_deliverable',
+            ).delete()
+
+            log.info('Done.')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.3',
+    version='1.1.5',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Addresses fallout from https://github.com/open-craft/xblock-group-project-v2/pull/121