### PR TITLE
Remove accidentally added document_id filter

### DIFF
--- a/edx_solutions_projects/management/commands/remove_accidentally_pasted_uploads.py
+++ b/edx_solutions_projects/management/commands/remove_accidentally_pasted_uploads.py
@@ -24,7 +24,6 @@ class Command(BaseCommand):
         if choice == 'y' or choice == 'yes':
             WorkgroupSubmission.objects.filter(
                 document_filename='image.png',
-                document_id=u'Kickoff_deliverable',
             ).delete()
 
             log.info('Done.')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.5',
+    version='1.1.6',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
While pushing PR #17 I accidentally left in a filter for the document id, this PR removes that unneeded filter. 