### PR TITLE
[MCKIN-8917] Delete uploaded file before deleting submission

### DIFF
--- a/edx_solutions_projects/migrations/0002_auto_20190228_0038.py
+++ b/edx_solutions_projects/migrations/0002_auto_20190228_0038.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edx_solutions_projects', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='workgroupsubmission',
+            name='user',
+            field=models.ForeignKey(related_name='submissions', on_delete=django.db.models.deletion.DO_NOTHING, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -133,7 +133,7 @@ class WorkgroupSubmission(TimeStampedModel):
     'Group Project' XBlock and data for a specific instance is persisted here
     """
     workgroup = models.ForeignKey(Workgroup, related_name="submissions")
-    user = models.ForeignKey(User, related_name="submissions")
+    user = models.ForeignKey(User, related_name="submissions", on_delete=models.DO_NOTHING)
     document_id = models.CharField(max_length=255)
     document_url = models.CharField(max_length=2048)
     document_mime_type = models.CharField(max_length=255)

--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -3,6 +3,8 @@
 from django.contrib.auth.models import Group, User
 from django.db import models
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
+
 
 from model_utils.models import TimeStampedModel
 
@@ -136,6 +138,18 @@ class WorkgroupSubmission(TimeStampedModel):
     document_url = models.CharField(max_length=2048)
     document_mime_type = models.CharField(max_length=255)
     document_filename = models.CharField(max_length=255, blank=True, null=True)
+
+    def delete_file(self):
+        """
+        Delete uploaded file before deleting the submission.
+        """
+        file_ = self.document_url.lstrip('/media/')
+
+        try:
+            default_storage.delete(file_)
+        except OSError:
+            # It doesn't exist anymore.
+            pass
 
 
 class WorkgroupSubmissionReview(TimeStampedModel):

--- a/edx_solutions_projects/receivers.py
+++ b/edx_solutions_projects/receivers.py
@@ -1,11 +1,13 @@
 """
 Signal handlers supporting various gradebook use cases
 """
+from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
 from util.signals import course_deleted
 
 from edx_solutions_projects import models
+from edx_solutions_projects.models import WorkgroupSubmission
 
 
 @receiver(course_deleted)
@@ -31,3 +33,8 @@ def on_course_deleted(sender, **kwargs):  # pylint: disable=W0613
                 models.WorkgroupUser.objects.filter(workgroup=workgroup).delete()
                 models.Workgroup.objects.filter(id=workgroup.id).delete()
             models.Project.objects.filter(id=project.id).delete()
+
+
+@receiver(pre_delete, sender=WorkgroupSubmission)
+def delete_image(_sender, instance, **_kwargs):
+    instance.delete_file()

--- a/edx_solutions_projects/receivers.py
+++ b/edx_solutions_projects/receivers.py
@@ -52,7 +52,7 @@ def reassign_or_delete_submissions(instance, **_kwargs):
 
 
 @receiver(post_delete, sender=WorkgroupUser)
-def delete_empty_group(instance, **_kwargs):
+def delete_empty_workgroup(instance, **_kwargs):
     """Delete workgroup after deleting its last participant."""
     workgroup = instance.workgroup
     if workgroup.users.count() == 0:

--- a/edx_solutions_projects/receivers.py
+++ b/edx_solutions_projects/receivers.py
@@ -37,13 +37,12 @@ def on_course_deleted(sender, **kwargs):  # pylint: disable=W0613
 
 @receiver(pre_delete, sender=WorkgroupUser)
 def reassign_or_delete_submissions(instance, **_kwargs):
-    """Reassigns submission if user is deleted and there are more users in the workgroup."""
+    """Reassigns submissions if user is deleted and there are more users in the workgroup. Otherwise deletes them."""
     submissions = instance.user.submissions.all()
-    others = set(instance.workgroup.users.all()) - set([instance.user])
+    next_user = instance.workgroup.users.exclude(id=instance.user.id).first()
 
-    if others:
+    if next_user:
         # Reassign submissions
-        next_user = others.pop()
         for submission in submissions:
             submission.user = next_user
             submission.save()

--- a/edx_solutions_projects/receivers.py
+++ b/edx_solutions_projects/receivers.py
@@ -7,7 +7,7 @@ from django.dispatch import receiver
 from util.signals import course_deleted
 
 from edx_solutions_projects import models
-from edx_solutions_projects.models import WorkgroupSubmission
+from edx_solutions_projects.models import WorkgroupSubmission, WorkgroupUser
 
 
 @receiver(course_deleted)
@@ -45,3 +45,11 @@ def reassign_or_delete_image(instance, **_kwargs):
         instance.save()
     else:
         instance.delete_file()
+
+
+@receiver(post_delete, sender=WorkgroupUser)
+def delete_empty_group(instance, **_kwargs):
+    """Delete workgroup after deleting its last participant."""
+    workgroup = instance.workgroup
+    if workgroup.users.count() == 0:
+        workgroup.delete()

--- a/edx_solutions_projects/tests/test_workgroup_submissions.py
+++ b/edx_solutions_projects/tests/test_workgroup_submissions.py
@@ -6,6 +6,7 @@ Run these tests: paver test_system -s lms -t edx_solutions_projects
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import TestCase
+from mock import patch
 
 from edx_solutions_projects.models import Project, Workgroup
 from edx_solutions_api_integration.test_utils import APIClientMixin
@@ -38,6 +39,11 @@ class SubmissionsApiTests(TestCase, APIClientMixin):
             username="testing",
             is_active=True
         )
+        self.test_user2 = User.objects.create(
+            email="test2@edx.org",
+            username="testing2",
+            is_active=True
+        )
 
         self.test_project = Project.objects.create(
             course_id=self.test_course_id,
@@ -49,6 +55,7 @@ class SubmissionsApiTests(TestCase, APIClientMixin):
             project=self.test_project,
         )
         self.test_workgroup.add_user(self.test_user)
+        self.test_workgroup.add_user(self.test_user2)
         self.test_workgroup.save()
 
         cache.clear()
@@ -140,7 +147,9 @@ class SubmissionsApiTests(TestCase, APIClientMixin):
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 404)
 
-    def test_submissions_detail_delete(self):
+    @patch('edx_solutions_projects.models.WorkgroupSubmission.delete_file')
+    def test_submissions_detail_delete(self, delete_file):
+        """Check deleting submission. Its file should be deleted too."""
         submission_data = {
             'user': self.test_user.id,
             'workgroup': self.test_workgroup.id,
@@ -156,5 +165,33 @@ class SubmissionsApiTests(TestCase, APIClientMixin):
         self.assertEqual(response.status_code, 200)
         response = self.do_delete(test_uri)
         self.assertEqual(response.status_code, 204)
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 404)
+
+        # Check if file has been deleted too
+        self.assertEqual(delete_file.call_count, 1)
+
+    def test_submissions_reassigned_on_user_delete(self):
+        """Test if removing the submission's owner causes its reassignment to another workgroup member."""
+        submission_data = {
+            'user': self.test_user.id,
+            'workgroup': self.test_workgroup.id,
+            'document_id': self.test_document_id,
+            'document_url': self.test_document_url,
+            'document_mime_type': self.test_document_mime_type,
+            'document_filename': self.test_document_filename,
+        }
+        response = self.do_post(self.test_submissions_uri, submission_data)
+        self.assertEqual(response.status_code, 201)
+        test_uri = '{}{}/'.format(self.test_submissions_uri, str(response.data['id']))
+
+        # Check if submission is reassigned after removing the first user
+        self.test_workgroup.remove_user(self.test_user)
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['user'], self.test_user2.id)
+
+        # Check if submission is deleted after removing the second user
+        self.test_workgroup.remove_user(self.test_user2)
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 404)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.6',
+    version='1.1.7',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Files uploaded by user will be automatically deleted on user's deletion.

### Testing instructions.
1. Add this to your `lms.env.json`:
    ```json
	"XBLOCK_SETTINGS": {
	  "group_project_v2": {
	    "dashboard_details_url": "/admin/workgroup/dashboard/programs/{program_id}/courses/{course_id}/projects/{project_id}/details?activate_block_id={activity_id}",
	    "ta_review_url": "/courses/{course_id}/group_work/{group_id}?activate_block_id={activate_block_id}",
	    "access_dashboard_for_all_orgs_groups": ["mcka_role_mcka_admin"],
	    "access_dashboard_groups": ["mcka_role_client_admin", "mcka_role_internal_admin"],
	    "access_dashboard_ta_groups": ["mcka_role_mcka_ta"],
	    "ta_roles": ["assistant"]
	  }
	}
    ```
1. Install/checkout this branch.
1. Go to Studio, create new course and use `Tools -> Import` to import [this course](https://github.com/open-craft/xblock-group-project-v2/blob/master/examples/sample_course.tar.gz).
1. Create two test users and enroll them into the course.
1. Log in with test user, go to the course -> "Group Work". Click the button with upload icon and upload some files. Complete the `Completion` task on the course.
1. Log in as admin and delete the first user via `Participants`.
1. Log in as the second user and check that uploaded files are still available.
1. Log in as admin and delete the second user via `Participants`.
1. Go to `Group Work`, check 'Access V2 Dashboard without programs' and check existing course to see that user's data is gone.
1. Go to `/edx/var/edxapp/media/group_work` and run `find -type f` to confirm that all files submitted files have been deleted successfully.

### Workaround for deletion
Currently deletion endpoint is broken. To fix it, remove the '/' suffix from `/static/js/views/admin/participantsinfo.js:403` and run `./manage.py collectstatic --noinput` on the Apros.