### PR TITLE
[MCKIN-10357] Fix deleting files from S3

### DIFF
--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -1,5 +1,7 @@
 """ Database ORM models managed by this Django app """
 
+from six.moves.urllib_parse import urlparse
+
 from django.contrib.auth.models import Group, User
 from django.db import models
 from django.core.exceptions import ValidationError
@@ -143,10 +145,10 @@ class WorkgroupSubmission(TimeStampedModel):
         """
         Delete uploaded file before deleting the submission.
         """
-        file_ = self.document_url.lstrip('/media/')
+        path = urlparse(self.document_url).path.lstrip('/media/')
 
         try:
-            default_storage.delete(file_)
+            default_storage.delete(path)
         except OSError:
             # It doesn't exist anymore.
             pass

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.7',
+    version='1.1.8',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
We keep URL of the submitted file in the DB, so we need to extract the path from it if we use S3 as a storage.

### Testing instructions.
1. Add this to your `lms.env.json`:
    ```json
	"XBLOCK_SETTINGS": {
	  "group_project_v2": {
	    "dashboard_details_url": "/admin/workgroup/dashboard/programs/{program_id}/courses/{course_id}/projects/{project_id}/details?activate_block_id={activity_id}",
	    "ta_review_url": "/courses/{course_id}/group_work/{group_id}?activate_block_id={activate_block_id}",
	    "access_dashboard_for_all_orgs_groups": ["mcka_role_mcka_admin"],
	    "access_dashboard_groups": ["mcka_role_client_admin", "mcka_role_internal_admin"],
	    "access_dashboard_ta_groups": ["mcka_role_mcka_ta"],
	    "ta_roles": ["assistant"]
	  }
	}
    ```
1. Install/checkout this branch.
1. Go to Studio, create new course and use `Tools -> Import` to import [this course](https://github.com/open-craft/xblock-group-project-v2/blob/master/examples/sample_course.tar.gz).
1. Create two test users and enroll them into the course.
1. Log in with test user, go to the course -> "Group Work". Click the button with upload icon and upload some files. Complete the `Completion` task on the course.
1. Log in as admin and delete the first user via `Participants`.
1. Log in as the second user and check that uploaded files are still available.
1. Log in as admin and delete the second user via `Participants`.
1. Go to `Group Work`, check 'Access V2 Dashboard without programs' and check existing course to see that user's data is gone.
1. Go to `/edx/var/edxapp/media/group_work` and run `find -type f` to confirm that all files submitted files have been deleted successfully.