### PR TITLE
MCKIN-8916 Unquote url for S3 deletion

### DIFF
--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -142,11 +142,18 @@ class WorkgroupSubmission(TimeStampedModel):
     document_mime_type = models.CharField(max_length=255)
     document_filename = models.CharField(max_length=255, blank=True, null=True)
 
+    @property
+    def document_path(self):
+        """
+        :return: the path to the document in default storage
+        """
+        return urlparse(unquote(self.document_url)).path
+
     def delete_file(self):
         """
         Delete uploaded file before deleting the submission.
         """
-        path = urlparse(unquote(self.document_url)).path.lstrip('/media/')
+        path = self.document_path.lstrip('/media/')
         default_storage.delete(path)
 
 

--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -1,6 +1,7 @@
 """ Database ORM models managed by this Django app """
 
 from six.moves.urllib_parse import urlparse
+from urllib import unquote
 
 from django.contrib.auth.models import Group, User
 from django.db import models
@@ -145,13 +146,8 @@ class WorkgroupSubmission(TimeStampedModel):
         """
         Delete uploaded file before deleting the submission.
         """
-        path = urlparse(self.document_url).path.lstrip('/media/')
-
-        try:
-            default_storage.delete(path)
-        except OSError:
-            # It doesn't exist anymore.
-            pass
+        path = urlparse(unquote(self.document_url)).path.lstrip('/media/')
+        default_storage.delete(path)
 
 
 class WorkgroupSubmissionReview(TimeStampedModel):

--- a/edx_solutions_projects/models.py
+++ b/edx_solutions_projects/models.py
@@ -147,14 +147,13 @@ class WorkgroupSubmission(TimeStampedModel):
         """
         :return: the path to the document in default storage
         """
-        return urlparse(unquote(self.document_url)).path
+        return urlparse(unquote(self.document_url)).path.lstrip('/media/')
 
     def delete_file(self):
         """
         Delete uploaded file before deleting the submission.
         """
-        path = self.document_path.lstrip('/media/')
-        default_storage.delete(path)
+        default_storage.delete(self.document_path)
 
 
 class WorkgroupSubmissionReview(TimeStampedModel):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.8',
+    version='1.1.9',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
When deleting a submission file, the document URL is parsed and must be unquoted to account for the real path.

Testing
----------

1. Make sure `edx-plataform` is restarted and this version is installed.
2. Create a workgroup submission and make sure the **filename contains spaces**. Note the url to the uploaded file.
3. Delete the submission using the console or delete the user:
```python
>>> from django.core.files.storage import default_storage
>>> from edx_solutions_projects import models
>>> sub = models.WorkgroupSubmission.objects.last()
>>> default_storage.exists(sub.document_path)
True
>>> default_storage.delete(sub.document_path)
>>> default_storage.exists(sub.document_path)
False
```
4. Ensure the file was deleted by trying to downloaded with the noted url.