### PR TITLE
Provide endpoint to query workgroup score

### DIFF
--- a/edx_solutions_projects/serializers.py
+++ b/edx_solutions_projects/serializers.py
@@ -162,8 +162,34 @@ class WorkgroupSerializer(serializers.HyperlinkedModelSerializer):
         )
 
 
-class WorkgroupDetailsSerializer(WorkgroupSerializer):
+class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta(object):
+        """ Meta class for defining additional serializer characteristics """
+        model = Organization
+        fields = ('id', 'display_name')
+
+
+class UserDetailsSerializer(serializers.HyperlinkedModelSerializer):
+    organizations = OrganizationSerializer(many=True, required=False)
+
+    class Meta(object):
+        """ Meta class for defining additional serializer characteristics """
+        model = User
+        fields = ('id', 'url', 'username', 'email', 'first_name', 'last_name', 'organizations')
+
+
+class WorkgroupDetailsSerializer(serializers.HyperlinkedModelSerializer):
     submissions = WorkgroupSubmissionSerializer(many=True, read_only=True)
+    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
+    users = UserDetailsSerializer(many=True, required=False)
+
+    class Meta:
+        """ Meta class for defining additional serializer characteristics """
+        model = Workgroup
+        fields = (
+            'id', 'url', 'created', 'modified', 'name', 'project',
+            'users', 'submissions',
+        )
 
 
 class BasicWorkgroupSerializer(serializers.HyperlinkedModelSerializer):

--- a/edx_solutions_projects/serializers.py
+++ b/edx_solutions_projects/serializers.py
@@ -162,34 +162,8 @@ class WorkgroupSerializer(serializers.HyperlinkedModelSerializer):
         )
 
 
-class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta(object):
-        """ Meta class for defining additional serializer characteristics """
-        model = Organization
-        fields = ('id', 'display_name')
-
-
-class UserDetailsSerializer(serializers.HyperlinkedModelSerializer):
-    organizations = OrganizationSerializer(many=True, required=False)
-
-    class Meta(object):
-        """ Meta class for defining additional serializer characteristics """
-        model = User
-        fields = ('id', 'url', 'username', 'email', 'first_name', 'last_name', 'organizations')
-
-
-class WorkgroupDetailsSerializer(serializers.HyperlinkedModelSerializer):
+class WorkgroupDetailsSerializer(WorkgroupSerializer):
     submissions = WorkgroupSubmissionSerializer(many=True, read_only=True)
-    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
-    users = UserDetailsSerializer(many=True, required=False)
-
-    class Meta:
-        """ Meta class for defining additional serializer characteristics """
-        model = Workgroup
-        fields = (
-            'id', 'url', 'created', 'modified', 'name', 'project',
-            'users', 'submissions',
-        )
 
 
 class BasicWorkgroupSerializer(serializers.HyperlinkedModelSerializer):

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -358,6 +358,24 @@ class ProjectsViewSet(SecureModelViewSet):
                 'not_enrolled_users': list(not_enrolled_users)
             }, status=status.HTTP_400_BAD_REQUEST)
 
+        workgroups = Workgroup.objects.filter(name__in=list(groups), project=project)
+        workgroups = {w.name: w for w in workgroups}
+        new_workgroups = []
+        for group in groups:
+            if group not in workgroups:
+                new_workgroups += [
+                    Workgroup(name=group, project=project)
+                ]
+
+        if new_workgroups:
+            Workgroup.objects.bulk_create(new_workgroups)
+
+        all_workgroups = Workgroup.objects.filter(name__in=list(groups), project=project)
+        for workgroup in all_workgroups:
+            if workgroup.name not in workgroups:
+                add_cohort(course_key, workgroup.cohort_name, CourseCohort.RANDOM)
+                workgroups[workgroup.name] = workgroup
+
         return Response({}, status=status.HTTP_201_CREATED)
 
 

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -316,7 +316,7 @@ class ProjectsViewSet(SecureModelViewSet):
             serializer_cls = WorkgroupSerializer
             if 'details' in request.query_params:
                 serializer_cls = WorkgroupDetailsSerializer
-                workgroups = workgroups.prefetch_related('submissions')
+                workgroups.prefetch_related('submissions', 'users', 'users__organizations')
             response_data = []
             if workgroups:
                 for workgroup in workgroups:

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -2,24 +2,31 @@
 # pylint: disable=W0613
 
 """ WORKGROUPS API VIEWS """
+from django.db.models import Q
+from django.db.models.signals import pre_delete, post_delete
+from edx_solutions_projects.receivers import reassign_or_delete_submissions, delete_empty_workgroup
+
+from common.test.utils import skip_signal
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.models import Group, User
 from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from eventtracking import tracker
 
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework import status
 from rest_framework.response import Response
 
+from lms.djangoapps.courseware import courses
 from lms.djangoapps.grades.signals.signals import SCORE_PUBLISHED
-from openedx.core.djangoapps.course_groups.models import CourseCohort
+from openedx.core.djangoapps.course_groups.models import CourseCohort, CourseUserGroup, CohortMembership
 
 from edx_solutions_api_integration.permissions import SecureModelViewSet
 from edx_solutions_api_integration.courseware_access import get_course_key
 from courseware.courses import get_course
-from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.keys import UsageKey
 from opaque_keys import InvalidKeyError
 from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.course_groups.cohorts import (
@@ -27,7 +34,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 )
 from student.models import CourseEnrollment
 
-from .models import Project, Workgroup, WorkgroupSubmission
+from .models import Project, Workgroup, WorkgroupSubmission, WorkgroupUser
 from .models import WorkgroupReview, WorkgroupSubmissionReview, WorkgroupPeerReview
 from .serializers import UserSerializer, GroupSerializer, WorkgroupDetailsSerializer
 from .serializers import ProjectSerializer, WorkgroupSerializer, WorkgroupSubmissionSerializer
@@ -317,7 +324,7 @@ class ProjectsViewSet(SecureModelViewSet):
             serializer_cls = WorkgroupSerializer
             if 'details' in request.query_params:
                 serializer_cls = WorkgroupDetailsSerializer
-                workgroups.prefetch_related('submissions', 'users', 'users__organizations')
+                workgroups = workgroups.prefetch_related('submissions', 'users', 'users__organizations')
             response_data = []
             if workgroups:
                 for workgroup in workgroups:
@@ -337,46 +344,181 @@ class ProjectsViewSet(SecureModelViewSet):
             return Response({}, status=status.HTTP_201_CREATED)
 
     @detail_route(methods=['post'])
+    @method_decorator(transaction.non_atomic_requests)
     def workgroups_bulk(self, request, pk):
-        project = Project.objects.filter(pk=pk).first()
-        if not project:
+        self.project = Project.objects.filter(pk=pk).first()
+        if not self.project:
             return Response({}, status=status.HTTP_404_NOT_FOUND)
 
-        course_key = get_course_key(project.course_id)
-        groups = request.data.get('groups', {})
-        users = sum(list(groups.values()), [])
+        self.course_key = get_course_key(self.project.course_id)
+        self.groups = request.data.get('groups', {})
+        users = sum(list(self.groups.values()), [])
         users = [u.lower() for u in users]
         enrollments = CourseEnrollment.objects.filter(
-            course_id=course_key,
+            course_id=self.course_key,
             is_active=True,
             user__email__in=users
-        ).values_list('id', 'user__email')
-        enrolled_users = {u.lower(): i for i, u in enrollments}
-        not_enrolled_users = set(users) - set(enrolled_users)
+        ).values_list('user__id', 'user__email')
+
+        self.enrolled_users = {u.lower(): i for i, u in enrollments}
+        not_enrolled_users = set(users) - set(self.enrolled_users)
         if not_enrolled_users:
             return Response({
                 'not_enrolled_users': list(not_enrolled_users)
             }, status=status.HTTP_400_BAD_REQUEST)
 
-        workgroups = Workgroup.objects.filter(name__in=list(groups), project=project)
-        workgroups = {w.name: w for w in workgroups}
+        self.user_ids = list(self.enrolled_users.values())
+
+        # Delete and recreate workgroups
+        self._delete_groups()
+        self._create_new_workgroups()
+
+        # Delete and recreate cohort groups and memberships
+        workgroups = self._get_workgroups()
+        memberships, user_group = self._get_course_membership_and_groups(workgroups)
+        self._delete_cohort_groups_and_users(memberships)
+        self._create_cohort_groups_and_memberships(workgroups, user_group, memberships)
+        return Response({}, status=status.HTTP_201_CREATED)
+
+    def _create_new_workgroups(self):
+        workgroups = self._get_workgroups()
+        # Create workgroups that are not already in DB.
         new_workgroups = []
-        for group in groups:
+        for group in self.groups:
             if group not in workgroups:
-                new_workgroups += [
-                    Workgroup(name=group, project=project)
-                ]
+                new_workgroups += [Workgroup(name=group, project=self.project)]
 
         if new_workgroups:
             Workgroup.objects.bulk_create(new_workgroups)
 
-        all_workgroups = Workgroup.objects.filter(name__in=list(groups), project=project)
-        for workgroup in all_workgroups:
-            if workgroup.name not in workgroups:
-                add_cohort(course_key, workgroup.cohort_name, CourseCohort.RANDOM)
-                workgroups[workgroup.name] = workgroup
+        all_workgroups = self._get_workgroups()
+        self._add_workgroups_to_cohorts(all_workgroups, workgroups)
 
-        return Response({}, status=status.HTTP_201_CREATED)
+    def _create_cohort_groups_and_memberships(self, workgroups, user_group, memberships):
+        GroupUserModel = CourseUserGroup.users.through._meta.model
+        new_workgroup_users = []
+        new_cohort_memberships = []
+        new_cohort_group_users = []
+        for group, users in self.groups.items():
+            for email in users:
+                user_id = self.enrolled_users[email.lower()]
+                wg = workgroups[group]
+                workgroup_id = wg['id']
+                cohort_name = wg['cohort_name']
+                user_group_id = user_group[cohort_name]
+                new_workgroup_users += [WorkgroupUser(workgroup_id=workgroup_id, user_id=user_id)]
+                new_cohort_memberships += [CohortMembership(
+                    course_user_group_id=user_group_id,
+                    user_id=user_id,
+                    course_id=self.course_key
+                )]
+                new_cohort_group_users += [GroupUserModel(courseusergroup_id=user_group_id, user_id=user_id)]
+
+                membership = memberships.get(user_id, {})
+                tracker.emit(
+                    "edx.cohort.user_add_requested",
+                    {
+                        "user_id": user_id,
+                        "cohort_id": user_group_id,
+                        "cohort_name": cohort_name,
+                        "previous_cohort_id": membership.get('id'),
+                        "previous_cohort_name": membership.get('name'),
+                    }
+                )
+
+        if new_workgroup_users:
+            WorkgroupUser.objects.bulk_create(new_workgroup_users)
+        if new_cohort_memberships:
+            CohortMembership.objects.bulk_create(new_cohort_memberships)
+        if new_cohort_group_users:
+            GroupUserModel.objects.bulk_create(new_cohort_group_users)
+
+    def _add_workgroups_to_cohorts(self, all_workgroups, workgroups):
+        course = courses.get_course_by_id(self.course_key)
+        course_id = course.id
+        cohorts = [w['cohort_name'] for w in all_workgroups.values()if w['name'] not in workgroups]
+        objects = []
+        for cohort_name in cohorts:
+            cug = CourseUserGroup(name=cohort_name, course_id=course_id, group_type=CourseUserGroup.COHORT)
+            objects += [cug]
+        if objects:
+            CourseUserGroup.objects.bulk_create(objects)
+
+        user_groups = CourseUserGroup.objects.filter(
+            name__in=cohorts,
+            course_id=course_id,
+            group_type=CourseUserGroup.COHORT
+        ).values_list('name', 'id')
+        user_groups = dict(user_groups)
+
+        objects = []
+        for cohort_name in cohorts:
+            course_user_group = user_groups[cohort_name]
+            cc = CourseCohort(course_user_group_id=course_user_group, assignment_type=CourseCohort.RANDOM)
+            objects += [cc]
+
+        if objects:
+            CourseCohort.objects.bulk_create(objects)
+
+    def _get_workgroups(self):
+        raw_workgroups = Workgroup.objects.filter(
+            name__in=list(self.groups),
+            project=self.project
+        ).values('id', 'project_id', 'name')
+
+        workgroups = {}
+        for workgroup in raw_workgroups:
+            project_id = workgroup['project_id']
+            workgroup_id = workgroup['id']
+            workgroup_name = workgroup['name']
+            workgroup['cohort_name'] = Workgroup.cohort_name_for_workgroup(
+                project_id, workgroup_id, workgroup_name
+            )
+            workgroups[workgroup_name] = workgroup
+
+        return workgroups
+
+    def _get_course_membership_and_groups(self, workgroups):
+        user_groups = CourseUserGroup.objects.filter(
+            course_id=self.course_key,
+            group_type=CourseUserGroup.COHORT,
+            name__in=[w['cohort_name'] for w in workgroups.values()]
+        ).values_list('id', 'name')
+        user_group = {n: i for i, n in user_groups}
+
+        memberships = CohortMembership.objects.filter(
+            course_id=self.course_key,
+            user_id__in=self.user_ids
+        ).values_list(
+            'user_id',
+            'course_user_group_id',
+            'course_user_group__name'
+        )
+        memberships = {u: {'id': m, 'name': n} for u, m, n in memberships}
+        return memberships, user_group
+
+    def _delete_groups(self):
+        with skip_signal(pre_delete, receiver=reassign_or_delete_submissions, sender=WorkgroupUser):
+            with skip_signal(post_delete, receiver=delete_empty_workgroup, sender=WorkgroupUser):
+                Workgroup.objects.filter(name__in=list(self.groups), project=self.project).delete()
+
+        WorkgroupUser.objects.filter(
+            user__in=list(self.enrolled_users.values()),
+            workgroup__project__course_id=self.course_key
+        ).delete()
+
+    def _delete_cohort_groups_and_users(self, memberships):
+        GroupUserModel = CourseUserGroup.users.through._meta.model
+        q = Q()
+        for user_id, group in memberships.items():
+            q |= Q(courseusergroup_id=group['id'], user_id=user_id)
+        GroupUserModel.objects.filter(q).delete()
+        from openedx.core.djangoapps.course_groups.models import remove_user_from_cohort as ch_signal
+        with skip_signal(pre_delete, receiver=ch_signal, sender=CohortMembership):
+            CohortMembership.objects.filter(
+                course_id=self.course_key,
+                user_id__in=self.user_ids
+            ).delete()
 
 
 class WorkgroupSubmissionsViewSet(viewsets.ModelViewSet):

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -2,39 +2,31 @@
 # pylint: disable=W0613
 
 """ WORKGROUPS API VIEWS """
-from django.db.models import Q
-from django.db.models.signals import pre_delete, post_delete
-from edx_solutions_projects.receivers import reassign_or_delete_submissions, delete_empty_workgroup
-
-from common.test.utils import skip_signal
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.models import Group, User
 from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from eventtracking import tracker
 
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework import status
 from rest_framework.response import Response
 
-from lms.djangoapps.courseware import courses
 from lms.djangoapps.grades.signals.signals import SCORE_PUBLISHED
-from openedx.core.djangoapps.course_groups.models import CourseCohort, CourseUserGroup, CohortMembership
+from openedx.core.djangoapps.course_groups.models import CourseCohort
 
 from edx_solutions_api_integration.permissions import SecureModelViewSet
 from edx_solutions_api_integration.courseware_access import get_course_key
 from courseware.courses import get_course
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys import InvalidKeyError
 from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.course_groups.cohorts import (
     add_cohort, add_user_to_cohort, get_cohort_by_name, remove_user_from_cohort,
 )
-from student.models import CourseEnrollment
 
-from .models import Project, Workgroup, WorkgroupSubmission, WorkgroupUser
+from .models import Project, Workgroup, WorkgroupSubmission
 from .models import WorkgroupReview, WorkgroupSubmissionReview, WorkgroupPeerReview
 from .serializers import UserSerializer, GroupSerializer, WorkgroupDetailsSerializer
 from .serializers import ProjectSerializer, WorkgroupSerializer, WorkgroupSubmissionSerializer
@@ -324,7 +316,7 @@ class ProjectsViewSet(SecureModelViewSet):
             serializer_cls = WorkgroupSerializer
             if 'details' in request.query_params:
                 serializer_cls = WorkgroupDetailsSerializer
-                workgroups = workgroups.prefetch_related('submissions', 'users', 'users__organizations')
+                workgroups.prefetch_related('submissions', 'users', 'users__organizations')
             response_data = []
             if workgroups:
                 for workgroup in workgroups:
@@ -342,183 +334,6 @@ class ProjectsViewSet(SecureModelViewSet):
             project.workgroups.add(workgroup)
             project.save()
             return Response({}, status=status.HTTP_201_CREATED)
-
-    @detail_route(methods=['post'])
-    @method_decorator(transaction.non_atomic_requests)
-    def workgroups_bulk(self, request, pk):
-        self.project = Project.objects.filter(pk=pk).first()
-        if not self.project:
-            return Response({}, status=status.HTTP_404_NOT_FOUND)
-
-        self.course_key = get_course_key(self.project.course_id)
-        self.groups = request.data.get('groups', {})
-        users = sum(list(self.groups.values()), [])
-        users = [u.lower() for u in users]
-        enrollments = CourseEnrollment.objects.filter(
-            course_id=self.course_key,
-            is_active=True,
-            user__email__in=users
-        ).values_list('user__id', 'user__email')
-
-        self.enrolled_users = {u.lower(): i for i, u in enrollments}
-        not_enrolled_users = set(users) - set(self.enrolled_users)
-        if not_enrolled_users:
-            return Response({
-                'not_enrolled_users': list(not_enrolled_users)
-            }, status=status.HTTP_400_BAD_REQUEST)
-
-        self.user_ids = list(self.enrolled_users.values())
-
-        # Delete and recreate workgroups
-        self._delete_groups()
-        self._create_new_workgroups()
-
-        # Delete and recreate cohort groups and memberships
-        workgroups = self._get_workgroups()
-        memberships, user_group = self._get_course_membership_and_groups(workgroups)
-        self._delete_cohort_groups_and_users(memberships)
-        self._create_cohort_groups_and_memberships(workgroups, user_group, memberships)
-        return Response({}, status=status.HTTP_201_CREATED)
-
-    def _create_new_workgroups(self):
-        workgroups = self._get_workgroups()
-        # Create workgroups that are not already in DB.
-        new_workgroups = []
-        for group in self.groups:
-            if group not in workgroups:
-                new_workgroups += [Workgroup(name=group, project=self.project)]
-
-        if new_workgroups:
-            Workgroup.objects.bulk_create(new_workgroups)
-
-        all_workgroups = self._get_workgroups()
-        self._add_workgroups_to_cohorts(all_workgroups, workgroups)
-
-    def _create_cohort_groups_and_memberships(self, workgroups, user_group, memberships):
-        GroupUserModel = CourseUserGroup.users.through._meta.model
-        new_workgroup_users = []
-        new_cohort_memberships = []
-        new_cohort_group_users = []
-        for group, users in self.groups.items():
-            for email in users:
-                user_id = self.enrolled_users[email.lower()]
-                wg = workgroups[group]
-                workgroup_id = wg['id']
-                cohort_name = wg['cohort_name']
-                user_group_id = user_group[cohort_name]
-                new_workgroup_users += [WorkgroupUser(workgroup_id=workgroup_id, user_id=user_id)]
-                new_cohort_memberships += [CohortMembership(
-                    course_user_group_id=user_group_id,
-                    user_id=user_id,
-                    course_id=self.course_key
-                )]
-                new_cohort_group_users += [GroupUserModel(courseusergroup_id=user_group_id, user_id=user_id)]
-
-                membership = memberships.get(user_id, {})
-                tracker.emit(
-                    "edx.cohort.user_add_requested",
-                    {
-                        "user_id": user_id,
-                        "cohort_id": user_group_id,
-                        "cohort_name": cohort_name,
-                        "previous_cohort_id": membership.get('id'),
-                        "previous_cohort_name": membership.get('name'),
-                    }
-                )
-
-        if new_workgroup_users:
-            WorkgroupUser.objects.bulk_create(new_workgroup_users)
-        if new_cohort_memberships:
-            CohortMembership.objects.bulk_create(new_cohort_memberships)
-        if new_cohort_group_users:
-            GroupUserModel.objects.bulk_create(new_cohort_group_users)
-
-    def _add_workgroups_to_cohorts(self, all_workgroups, workgroups):
-        course = courses.get_course_by_id(self.course_key)
-        course_id = course.id
-        cohorts = [w['cohort_name'] for w in all_workgroups.values()if w['name'] not in workgroups]
-        objects = []
-        for cohort_name in cohorts:
-            cug = CourseUserGroup(name=cohort_name, course_id=course_id, group_type=CourseUserGroup.COHORT)
-            objects += [cug]
-        if objects:
-            CourseUserGroup.objects.bulk_create(objects)
-
-        user_groups = CourseUserGroup.objects.filter(
-            name__in=cohorts,
-            course_id=course_id,
-            group_type=CourseUserGroup.COHORT
-        ).values_list('name', 'id')
-        user_groups = dict(user_groups)
-
-        objects = []
-        for cohort_name in cohorts:
-            course_user_group = user_groups[cohort_name]
-            cc = CourseCohort(course_user_group_id=course_user_group, assignment_type=CourseCohort.RANDOM)
-            objects += [cc]
-
-        if objects:
-            CourseCohort.objects.bulk_create(objects)
-
-    def _get_workgroups(self):
-        raw_workgroups = Workgroup.objects.filter(
-            name__in=list(self.groups),
-            project=self.project
-        ).values('id', 'project_id', 'name')
-
-        workgroups = {}
-        for workgroup in raw_workgroups:
-            project_id = workgroup['project_id']
-            workgroup_id = workgroup['id']
-            workgroup_name = workgroup['name']
-            workgroup['cohort_name'] = Workgroup.cohort_name_for_workgroup(
-                project_id, workgroup_id, workgroup_name
-            )
-            workgroups[workgroup_name] = workgroup
-
-        return workgroups
-
-    def _get_course_membership_and_groups(self, workgroups):
-        user_groups = CourseUserGroup.objects.filter(
-            course_id=self.course_key,
-            group_type=CourseUserGroup.COHORT,
-            name__in=[w['cohort_name'] for w in workgroups.values()]
-        ).values_list('id', 'name')
-        user_group = {n: i for i, n in user_groups}
-
-        memberships = CohortMembership.objects.filter(
-            course_id=self.course_key,
-            user_id__in=self.user_ids
-        ).values_list(
-            'user_id',
-            'course_user_group_id',
-            'course_user_group__name'
-        )
-        memberships = {u: {'id': m, 'name': n} for u, m, n in memberships}
-        return memberships, user_group
-
-    def _delete_groups(self):
-        with skip_signal(pre_delete, receiver=reassign_or_delete_submissions, sender=WorkgroupUser):
-            with skip_signal(post_delete, receiver=delete_empty_workgroup, sender=WorkgroupUser):
-                Workgroup.objects.filter(name__in=list(self.groups), project=self.project).delete()
-
-        WorkgroupUser.objects.filter(
-            user__in=list(self.enrolled_users.values()),
-            workgroup__project__course_id=self.course_key
-        ).delete()
-
-    def _delete_cohort_groups_and_users(self, memberships):
-        GroupUserModel = CourseUserGroup.users.through._meta.model
-        q = Q()
-        for user_id, group in memberships.items():
-            q |= Q(courseusergroup_id=group['id'], user_id=user_id)
-        GroupUserModel.objects.filter(q).delete()
-        from openedx.core.djangoapps.course_groups.models import remove_user_from_cohort as ch_signal
-        with skip_signal(pre_delete, receiver=ch_signal, sender=CohortMembership):
-            CohortMembership.objects.filter(
-                course_id=self.course_key,
-                user_id__in=self.user_ids
-            ).delete()
 
 
 class WorkgroupSubmissionsViewSet(viewsets.ModelViewSet):

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -316,7 +316,7 @@ class ProjectsViewSet(SecureModelViewSet):
             serializer_cls = WorkgroupSerializer
             if 'details' in request.query_params:
                 serializer_cls = WorkgroupDetailsSerializer
-                workgroups.prefetch_related('submissions', 'users', 'users__organizations')
+                workgroups = workgroups.prefetch_related('submissions')
             response_data = []
             if workgroups:
                 for workgroup in workgroups:

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.course_groups.models import CourseCohort
 from edx_solutions_api_integration.permissions import SecureModelViewSet
 from edx_solutions_api_integration.courseware_access import get_course_key
 from courseware.courses import get_course
-from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.keys import UsageKey
 from opaque_keys import InvalidKeyError
 from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.course_groups.cohorts import (
@@ -210,10 +210,12 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
         """
         block_id = self.request.query_params.get('block_id', None)
         if not block_id:
-            raise ValidationError('Query string for "block_id" is required.')
+            message = 'Query string for "block_id" is required.'
+            return Response({'detail': message}, status=status.HTTP_400_BAD_REQUEST)
         child_key = UsageKey.from_string(block_id)
         if child_key.category != 'gp-v2-activity':
-            raise ValidationError('The "block_id" should point to a "gp-v2-activity" block.')
+            message = 'The "block_id" should point to a "gp-v2-activity" block.'
+            return Response({'detail': message}, status=status.HTTP_400_BAD_REQUEST)
         descriptor = modulestore().get_item(child_key)
         score = descriptor.calculate_grade(group_id=pk)
         return Response({'score': score}, status=status.HTTP_200_OK)

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -208,10 +208,12 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
         """
         View final score for a specific Workgroup
         """
-        content_id = self.request.query_params.get('content_id', None)
-        if not content_id:
-            return Response({'detail': 'Query string for "content_id" is required.'})
-        child_key = UsageKey.from_string(content_id)
+        block_id = self.request.query_params.get('block_id', None)
+        if not block_id:
+            raise ValidationError('Query string for "block_id" is required.')
+        child_key = UsageKey.from_string(block_id)
+        if child_key.category != 'gp-v2-activity':
+            raise ValidationError('The "block_id" should point to a "gp-v2-activity" block.')
         descriptor = modulestore().get_item(child_key)
         score = descriptor.calculate_grade(group_id=pk)
         return Response({'score': score}, status=status.HTTP_200_OK)

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -208,7 +208,10 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
         """
         View final score for a specific Workgroup
         """
-        child_key = UsageKey.from_string(self.request.query_params.get('content_id'))
+        content_id = self.request.query_params.get('content_id', None)
+        if not content_id:
+            return Response({'detail': 'Query string for "content_id" is required.'})
+        child_key = UsageKey.from_string(content_id)
         descriptor = modulestore().get_item(child_key)
         score = descriptor.calculate_grade(group_id=pk)
         return Response({'score': score}, status=status.HTTP_200_OK)

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -25,6 +25,7 @@ from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.course_groups.cohorts import (
     add_cohort, add_user_to_cohort, get_cohort_by_name, remove_user_from_cohort,
 )
+from student.models import CourseEnrollment
 
 from .models import Project, Workgroup, WorkgroupSubmission
 from .models import WorkgroupReview, WorkgroupSubmissionReview, WorkgroupPeerReview
@@ -334,6 +335,30 @@ class ProjectsViewSet(SecureModelViewSet):
             project.workgroups.add(workgroup)
             project.save()
             return Response({}, status=status.HTTP_201_CREATED)
+
+    @detail_route(methods=['post'])
+    def workgroups_bulk(self, request, pk):
+        project = Project.objects.filter(pk=pk).first()
+        if not project:
+            return Response({}, status=status.HTTP_404_NOT_FOUND)
+
+        course_key = get_course_key(project.course_id)
+        groups = request.data.get('groups', {})
+        users = sum(list(groups.values()), [])
+        users = [u.lower() for u in users]
+        enrollments = CourseEnrollment.objects.filter(
+            course_id=course_key,
+            is_active=True,
+            user__email__in=users
+        ).values_list('id', 'user__email')
+        enrolled_users = {u.lower(): i for i, u in enrollments}
+        not_enrolled_users = set(users) - set(enrolled_users)
+        if not_enrolled_users:
+            return Response({
+                'not_enrolled_users': list(not_enrolled_users)
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({}, status=status.HTTP_201_CREATED)
 
 
 class WorkgroupSubmissionsViewSet(viewsets.ModelViewSet):

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -204,6 +204,16 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
         return Response(response_data, status=status.HTTP_200_OK)
 
     @detail_route(methods=['get'])
+    def score(self, request, pk):
+        """
+        View final score for a specific Workgroup
+        """
+        child_key = UsageKey.from_string(self.request.query_params.get('content_id'))
+        descriptor = modulestore().get_item(child_key)
+        score = descriptor.calculate_grade(group_id=pk)
+        return Response({'score': score}, status=status.HTTP_200_OK)
+
+    @detail_route(methods=['get'])
     def submissions(self, request, pk):
         """
         View Submissions for a specific Workgroup

--- a/edx_solutions_projects/views.py
+++ b/edx_solutions_projects/views.py
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.course_groups.models import CourseCohort
 from edx_solutions_api_integration.permissions import SecureModelViewSet
 from edx_solutions_api_integration.courseware_access import get_course_key
 from courseware.courses import get_course
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys import InvalidKeyError
 from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.course_groups.cohorts import (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.17',
+    version='2.0.0',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.16',
+    version='1.1.15',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='2.0.0',
+    version='2.0.2',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='2.0.1',
+    version='1.1.15',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.15',
+    version='1.1.14',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.14',
+    version='1.1.17',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='projects-edx-platform-extensions',
-    version='1.1.15',
+    version='1.1.16',
     description='Projects management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Description
=========

This PR implements an API endpoint to provide score calculated by the XBlock so custom frontends don't have to recalculate the scores.

Testing
--------

1. Install this branch in your `edx-solutions` virtualenv and restart the edx platform development server.
1. Browser to the endpoint, `http://localhost:8000/api/server/workgroups/<workgroup_id>/score/?content_id=<content_id>` replacing workgroup_id and content_id to values that point to a graded group work.